### PR TITLE
Disallow researching T6 armor before T5

### DIFF
--- a/common/technology/nhsc_tech_armor.txt
+++ b/common/technology/nhsc_tech_armor.txt
@@ -24,7 +24,7 @@ nhsc_tech_armor_6 = {
 	tier = 4
 	cost = @tier4cost2
 	weight = @tier4weight2
-	prerequisites = { "nhsc_tech_advanced_materials" }
+	prerequisites = { "nhsc_tech_advanced_materials" "tech_ship_armor_5" }
 
 	potential = {
 		NOT = { has_global_flag = ESC_armors_forbidden }


### PR DESCRIPTION
When playing the lite version I had an issue where I could research T6 armor before T5, while I haven't come across this in the original it's not explicitly excluded here so thought it would be best to include it.